### PR TITLE
`{README.md}`: Completes Result section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1968,6 +1968,28 @@ userTypeNonNull := graphql.NewObject(graphql.ObjectConfig{
 
 ---
 
+###### 8. **Directives @skip**
+
+Allows for conditional exclusion during execution.
+
+###### `graphql-js`
+
+```
+query ExampleQuery($skipUserName: Boolean!, $skipProductPrice: Boolean!, ...) {
+ // ...
+}
+```
+
+###### `graphql-go`
+
+```
+query ExampleQuery($skipUserName: Boolean!, $skipProductPrice: Boolean!, ...) {
+ // ...
+}
+```
+
+---
+
 This detailed breakdown forms the foundation for the Conclusions section, where we compare design patterns and resolver behaviors across implementations.
 
 This comparison demonstrates that the Go implementation faithfully reproduces the API design of the JavaScript reference implementation. The imperative construction of the type system remains consistent, aligning with the GraphQL Specification’s flexibility in schema definition styles while emphasizing programmatic control.

--- a/README.md
+++ b/README.md
@@ -2071,6 +2071,52 @@ mutationType := graphql.NewObject(graphql.ObjectConfig{
 
 ---
 
+###### 11. **Subscriptions**
+
+Represents an operation for subscribing to data.
+
+###### `graphql-js`
+
+```
+subscription: new GraphQLObjectType({
+  name: "RootSubscriptionType",
+  fields: {
+    userAdded: {
+      type: userType,
+      resolve() {
+        return {
+          type: "user",
+          id: `user-${Date.now()}`,
+          name: "New User Added",
+        };
+      },
+    },
+  },
+}),
+```
+
+###### `graphql-go`
+
+```
+subscriptionType := graphql.NewObject(graphql.ObjectConfig{
+	Name: "Subscription",
+	Fields: graphql.Fields{
+		"userAdded": &graphql.Field{
+			Type: userType,
+			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				return map[string]interface{}{
+					"type": "user",
+					"id":   fmt.Sprintf("user-%d", time.Now().Unix()),
+					"name": "New User Added",
+				}, nil
+			},
+		},
+	},
+})
+```
+
+---
+
 This detailed breakdown forms the foundation for the Conclusions section, where we compare design patterns and resolver behaviors across implementations.
 
 This comparison demonstrates that the Go implementation faithfully reproduces the API design of the JavaScript reference implementation. The imperative construction of the type system remains consistent, aligning with the GraphQL Specification’s flexibility in schema definition styles while emphasizing programmatic control.

--- a/README.md
+++ b/README.md
@@ -2012,6 +2012,65 @@ query ExampleQuery(... , $includeUserName: Boolean!, $includeProductPrice: Boole
 
 ---
 
+###### 11. **Mutations**
+
+Represents an operation to mutate data.
+
+###### `graphql-js`
+
+```
+mutation: new GraphQLObjectType({
+  name: "RootMutationType",
+  fields: {
+    createUser: {
+      type: userType,
+      args: {
+        input: {
+          description: "input for creating a user",
+          type: userInputType,
+        },
+      },
+      resolve(root, { input }) {
+        return {
+          type: "user",
+          id: `user-${Date.now()}`,
+          name: input.name,
+        };
+      },
+    },
+  },
+}),
+```
+
+###### `graphql-go`
+
+```
+mutationType := graphql.NewObject(graphql.ObjectConfig{
+	Name: "Mutation",
+	Fields: graphql.Fields{
+		"createUser": &graphql.Field{
+			Type: userType,
+			Args: graphql.FieldConfigArgument{
+				"input": &graphql.ArgumentConfig{
+					Description: "input for creating a user",
+					Type:        userInputType,
+				},
+			},
+			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				input := p.Args["input"].(map[string]interface{})
+				return map[string]interface{}{
+					"type": "user",
+					"id":   fmt.Sprintf("user-%d", time.Now().Unix()),
+					"name": input["name"],
+				}, nil
+			},
+		},
+	},
+})
+```
+
+---
+
 This detailed breakdown forms the foundation for the Conclusions section, where we compare design patterns and resolver behaviors across implementations.
 
 This comparison demonstrates that the Go implementation faithfully reproduces the API design of the JavaScript reference implementation. The imperative construction of the type system remains consistent, aligning with the GraphQL Specification’s flexibility in schema definition styles while emphasizing programmatic control.

--- a/README.md
+++ b/README.md
@@ -1904,7 +1904,7 @@ Represents a declaration that a type disallows null.
 
 ###### `graphql-js`
 
-```
+```js
 const userTypeNonNull = new GraphQLObjectType({
   name: "UserNonNull",
   description: "A user with non-null fields.",
@@ -1923,7 +1923,7 @@ const userTypeNonNull = new GraphQLObjectType({
 });
 ```
 
-```
+```js
 userNonNull: {
   type: userTypeNonNull,
   resolve() {
@@ -1937,7 +1937,7 @@ userNonNull: {
 
 ###### `graphql-go`
 
-```
+```go
 userTypeNonNull := graphql.NewObject(graphql.ObjectConfig{
 	Name:        "UserNonNull",
 	Description: "A user with non-null fields.",
@@ -1954,7 +1954,7 @@ userTypeNonNull := graphql.NewObject(graphql.ObjectConfig{
 })
 ```
 
-```
+```go
 "userNonNull": &graphql.Field{
 	Type: userTypeNonNull,
 	Resolve: func(p graphql.ResolveParams) (interface{}, error) {
@@ -1974,7 +1974,7 @@ Allows for conditional exclusion during execution.
 
 ###### `graphql-js`
 
-```
+```graphql
 query ExampleQuery($skipUserName: Boolean!, $skipProductPrice: Boolean!, ...) {
  // ...
 }
@@ -1982,7 +1982,7 @@ query ExampleQuery($skipUserName: Boolean!, $skipProductPrice: Boolean!, ...) {
 
 ###### `graphql-go`
 
-```
+```graphql
 query ExampleQuery($skipUserName: Boolean!, $skipProductPrice: Boolean!, ...) {
  // ...
 }
@@ -1996,7 +1996,7 @@ Allows for conditional inclusion during execution.
 
 ###### `graphql-js`
 
-```
+```graphql
 query ExampleQuery(... , $includeUserName: Boolean!, $includeProductPrice: Boolean!) {
  // ...
 }
@@ -2004,7 +2004,7 @@ query ExampleQuery(... , $includeUserName: Boolean!, $includeProductPrice: Boole
 
 ###### `graphql-go`
 
-```
+```graphql
 query ExampleQuery(... , $includeUserName: Boolean!, $includeProductPrice: Boolean!) {
  // ...
 }
@@ -2018,7 +2018,7 @@ Represents an operation to mutate data.
 
 ###### `graphql-js`
 
-```
+```js
 mutation: new GraphQLObjectType({
   name: "RootMutationType",
   fields: {
@@ -2044,7 +2044,7 @@ mutation: new GraphQLObjectType({
 
 ###### `graphql-go`
 
-```
+```go
 mutationType := graphql.NewObject(graphql.ObjectConfig{
 	Name: "Mutation",
 	Fields: graphql.Fields{
@@ -2077,7 +2077,7 @@ Represents an operation for subscribing to data.
 
 ###### `graphql-js`
 
-```
+```js
 subscription: new GraphQLObjectType({
   name: "RootSubscriptionType",
   fields: {
@@ -2097,7 +2097,7 @@ subscription: new GraphQLObjectType({
 
 ###### `graphql-go`
 
-```
+```go
 subscriptionType := graphql.NewObject(graphql.ObjectConfig{
 	Name: "Subscription",
 	Fields: graphql.Fields{

--- a/README.md
+++ b/README.md
@@ -1990,6 +1990,28 @@ query ExampleQuery($skipUserName: Boolean!, $skipProductPrice: Boolean!, ...) {
 
 ---
 
+###### 8. **Directives @include**
+
+Allows for conditional inclusion during execution.
+
+###### `graphql-js`
+
+```
+query ExampleQuery(... , $includeUserName: Boolean!, $includeProductPrice: Boolean!) {
+ // ...
+}
+```
+
+###### `graphql-go`
+
+```
+query ExampleQuery(... , $includeUserName: Boolean!, $includeProductPrice: Boolean!) {
+ // ...
+}
+```
+
+---
+
 This detailed breakdown forms the foundation for the Conclusions section, where we compare design patterns and resolver behaviors across implementations.
 
 This comparison demonstrates that the Go implementation faithfully reproduces the API design of the JavaScript reference implementation. The imperative construction of the type system remains consistent, aligning with the GraphQL Specification’s flexibility in schema definition styles while emphasizing programmatic control.

--- a/README.md
+++ b/README.md
@@ -1968,7 +1968,7 @@ userTypeNonNull := graphql.NewObject(graphql.ObjectConfig{
 
 ---
 
-###### 8. **Directives @skip**
+###### 9. **Directives @skip**
 
 Allows for conditional exclusion during execution.
 
@@ -1990,7 +1990,7 @@ query ExampleQuery($skipUserName: Boolean!, $skipProductPrice: Boolean!, ...) {
 
 ---
 
-###### 8. **Directives @include**
+###### 10. **Directives @include**
 
 Allows for conditional inclusion during execution.
 

--- a/README.md
+++ b/README.md
@@ -1898,6 +1898,76 @@ objectList: {
 
 ---
 
+###### 8. **Non Null**
+
+Represents a declaration that a type disallows null.
+
+###### `graphql-js`
+
+```
+const userTypeNonNull = new GraphQLObjectType({
+  name: "UserNonNull",
+  description: "A user with non-null fields.",
+  fields: () => {
+    return {
+      id: {
+        type: new GraphQLNonNull(GraphQLID),
+        description: "The non-null ID of the user.",
+      },
+      name: {
+        type: new GraphQLNonNull(GraphQLString),
+        description: "The non-null name of the user.",
+      },
+    };
+  },
+});
+```
+
+```
+userNonNull: {
+  type: userTypeNonNull,
+  resolve() {
+    return {
+      id: "user-non-null-1",
+      name: "John Doe Non-Null",
+    };
+  },
+},
+```
+
+###### `graphql-go`
+
+```
+userTypeNonNull := graphql.NewObject(graphql.ObjectConfig{
+	Name:        "UserNonNull",
+	Description: "A user with non-null fields.",
+	Fields: graphql.Fields{
+		"id": &graphql.Field{
+			Type:        graphql.NewNonNull(graphql.ID),
+			Description: "The non-null ID of the user.",
+		},
+		"name": &graphql.Field{
+			Type:        graphql.NewNonNull(graphql.String),
+			Description: "The non-null name of the user.",
+		},
+	},
+})
+```
+
+```
+"userNonNull": &graphql.Field{
+	Type: userTypeNonNull,
+	Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+		return map[string]interface{}{
+			"id":   "user-non-null-1",
+			"name": "John Doe Non-Null",
+		}, nil
+	},
+},
+```
+
+---
+
 This detailed breakdown forms the foundation for the Conclusions section, where we compare design patterns and resolver behaviors across implementations.
 
 This comparison demonstrates that the Go implementation faithfully reproduces the API design of the JavaScript reference implementation. The imperative construction of the type system remains consistent, aligning with the GraphQL Specification’s flexibility in schema definition styles while emphasizing programmatic control.


### PR DESCRIPTION
#### Details
- Closes: #237.
- `README.md`: improves Results markdown.
- `README.md`: adds Subscription section.
- `README.md`: adds Mutations section.
- `README.md`: fixes results numbering.
- `README.md`: adds Directives @include section.
- `README.md`: adds Directives @skip section.
- `README.md`: adds Non Null section.


#### Test Plan
:heavy_check_mark: Tested that the `Results` section renders as expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the README with new sections covering Non Null fields, directives (@skip and @include), mutations, and subscriptions in GraphQL.
  * Provided side-by-side examples for both JavaScript and Go implementations, including code snippets and explanations for each feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->