### PR TITLE
`{thesis,tesis}`: Adds `Development: Scope` sections.

### DIFF
--- a/Tesis - Español.md
+++ b/Tesis - Español.md
@@ -12,10 +12,11 @@
 8. [Marco Teórico](#marco-teórico)
 9. [Desarrollo: Metodología](#desarrollo-metodología)
 10. [Desarrollo: Requerimientos](#desarrollo-requerimientos)
-11. [Results: Type System](#results-type-system)
-12. [Results: Operational Equivalence](#results-operational-equivalence)
-13. [Results: Compatibility Validation](#results-compatibility-validation)
-14. [Conclusions](#conclusions)
+11. [Desarrollo: Alcance](#desarrollo-alcance)
+12. [Results: Type System](#results-type-system)
+13. [Results: Operational Equivalence](#results-operational-equivalence)
+14. [Results: Compatibility Validation](#results-compatibility-validation)
+15. [Conclusions](#conclusions)
 
 ---
 
@@ -333,6 +334,52 @@ La colaboración entre equipos multidisciplinarios fue una piedra angular del pr
 
 #### Flexibilidad
 - Debe permitir la integración de nuevas funcionalidades dentro del CLI.
+
+---
+
+## Desarrollo: Alcance
+
+### Objetivos de Investigación
+
+Esta investigación tiene como objetivo explorar la integración de GraphQL en el ecosistema de programación Go, centrándose tanto en la implementación de la especificación de GraphQL como en su validación de compatibilidad. El estudio establece una base técnica y metodológica para la evolución continua de bibliotecas open-source de GraphQL mediante herramientas automatizadas y entornos colaborativos de contribución.
+
+### Aclaraciones sobre el Alcance
+
+#### Implementación
+
+El alcance de la implementación se encuentra anclado a la implementación de referencia en JavaScript (`graphql-js`) en su versión 0.6.0. Aunque esta versión constituye la base del desarrollo, el proyecto promueve futuras mejoras mediante contribuciones de la comunidad, alineadas con principios de extensibilidad y compatibilidad retroactiva.
+
+Las mejoras no deben alterar la funcionalidad existente, a menos que sean impulsadas explícitamente por cambios en la implementación de referencia. La estabilidad es un objetivo clave, y la implementación es validada mediante aplicaciones reales en entornos de producción de múltiples organizaciones.
+
+La biblioteca reproduce el modelo imperativo de construcción de esquemas utilizado por `graphql-js`, lo que permite una interfaz completamente programable para interactuar con el sistema de tipos interno. La solidez del sistema se garantiza al replicar el conjunto original de pruebas unitarias, adaptado idiomáticamente para Go, asegurando paridad de características y coherencia de comportamiento.
+
+#### Validación de Compatibilidad
+
+La herramienta de validación de compatibilidad está diseñada como un componente externo, intencionalmente desacoplado de la implementación principal. Su arquitectura modular permite integrar futuras implementaciones de GraphQL más allá de las evaluadas en este estudio.
+
+La herramienta verifica la equivalencia en tiempo de ejecución mediante comparaciones basadas en introspección, enfocándose en la compatibilidad estructural entre sistemas de tipos. Además, sienta las bases para la integración con CI/CD, permitiendo que futuros mantenedores automaticen las verificaciones de compatibilidad durante los flujos de trabajo de desarrollo.
+
+### Identificación de Posibles Sesgos
+
+La implementación toma como referencia principal el diseño de `graphql-js`. Sin embargo, se realizan adaptaciones para ajustarse a las prácticas idiomáticas de Go, evitando patrones específicos del lenguaje JavaScript. Este proceso enfatiza la fidelidad conceptual sobre la replicación sintáctica.
+
+Asimismo, la herramienta de validación de compatibilidad se limita inicialmente a la versión 0.6.0 de `graphql-js`. Aunque esta restricción reduce su alcance inmediato, su diseño modular facilita su ampliación para futuras versiones u otras implementaciones de referencia.
+
+### Límites de la Investigación
+
+Esta investigación se limita explícitamente a evaluar y replicar el comportamiento de `graphql-js` en su versión 0.6.0. Si bien se considera la extensibilidad, los esfuerzos de validación y las conclusiones están limitados a dicha versión histórica.
+
+### Ámbitos Fuera del Alcance
+
+#### Limitaciones de Recursos
+
+Las siguientes iniciativas fueron consideradas conceptualmente para enriquecer la validación de compatibilidad, pero quedaron fuera del alcance de este estudio debido a limitaciones de tiempo y recursos. Se proponen como trabajos futuros:
+
+- **Pruebas de Compatibilidad Unitarias** ([GitHub][1]): Marco para validar coincidencias de nombre y salida de pruebas entre `graphql-js` y `graphql-go`.
+- **Aceptación de Usuario en Compatibilidad** ([GitHub][2]): Análisis centrado en el usuario para comparar métricas de adopción, patrones de retroalimentación y características de uso entre `graphql-js` y `graphql-go`.
+
+[1]: https://github.com/graphql-go/compatibility-unit-tests  
+[2]: https://github.com/graphql-go/compatibility-user-acceptance
 
 ---
 

--- a/Tesis - Español.md
+++ b/Tesis - Español.md
@@ -375,11 +375,11 @@ Esta investigación se limita explícitamente a evaluar y replicar el comportami
 
 Las siguientes iniciativas fueron consideradas conceptualmente para enriquecer la validación de compatibilidad, pero quedaron fuera del alcance de este estudio debido a limitaciones de tiempo y recursos. Se proponen como trabajos futuros:
 
-- **Pruebas de Compatibilidad Unitarias** ([GitHub][1]): Framework para validar nombres de pruebas unitarias entre `graphql-js` y `graphql-go`.
-- **Aceptación de Usuario en Compatibilidad** ([GitHub][2]): Análisis centrado en el usuario para comparar métricas de adopción, patrones de retroalimentación y características de uso entre `graphql-js` y `graphql-go`.
+- **Pruebas de Compatibilidad Unitarias** ([GitHub][4]): Framework para validar nombres de pruebas unitarias entre `graphql-js` y `graphql-go`.
+- **Aceptación de Usuario en Compatibilidad** ([GitHub][5]): Análisis centrado en el usuario para comparar métricas de adopción, patrones de retroalimentación y características de uso entre `graphql-js` y `graphql-go`.
 
-[1]: https://github.com/graphql-go/compatibility-unit-tests  
-[2]: https://github.com/graphql-go/compatibility-user-acceptance
+[4]: https://github.com/graphql-go/compatibility-unit-tests
+[5]: https://github.com/graphql-go/compatibility-user-acceptance
 
 ---
 

--- a/Tesis - Español.md
+++ b/Tesis - Español.md
@@ -375,7 +375,7 @@ Esta investigación se limita explícitamente a evaluar y replicar el comportami
 
 Las siguientes iniciativas fueron consideradas conceptualmente para enriquecer la validación de compatibilidad, pero quedaron fuera del alcance de este estudio debido a limitaciones de tiempo y recursos. Se proponen como trabajos futuros:
 
-- **Pruebas de Compatibilidad Unitarias** ([GitHub][1]): Marco para validar coincidencias de nombre y salida de pruebas entre `graphql-js` y `graphql-go`.
+- **Pruebas de Compatibilidad Unitarias** ([GitHub][1]): Framework para validar nombres de pruebas unitarias entre `graphql-js` y `graphql-go`.
 - **Aceptación de Usuario en Compatibilidad** ([GitHub][2]): Análisis centrado en el usuario para comparar métricas de adopción, patrones de retroalimentación y características de uso entre `graphql-js` y `graphql-go`.
 
 [1]: https://github.com/graphql-go/compatibility-unit-tests  

--- a/Thesis.md
+++ b/Thesis.md
@@ -12,10 +12,11 @@
 8. [Theory Framework](#theory-framework)
 9. [Development: Methodology](#development-methodology)
 10. [Development: Requirements](#development-requirements)
-11. [Results: Type System](#results-type-system)
-12. [Results: Operational Equivalence](#results-operational-equivalence)
-13. [Results: Compatibility Validation](#results-compatibility-validation)
-14. [Conclusions](#conclusions)
+11. [Development: Scope](#development-scope)
+12. [Results: Type System](#results-type-system)
+13. [Results: Operational Equivalence](#results-operational-equivalence)
+14. [Results: Compatibility Validation](#results-compatibility-validation)
+15. [Conclusions](#conclusions)
 
 ## Abstract
 
@@ -341,6 +342,52 @@ Collaboration was driven primarily through GitHub Issues and Pull Requests, ensu
 
 #### Flexibility
 - It must support the addition of new CLI features without significant architectural changes.
+
+---
+
+## Development: Scope
+
+### Research Goals
+
+This research aims to explore the integration of GraphQL within the Go programming ecosystem, focusing on both the implementation of the GraphQL specification and its compatibility validation. The study establishes a technical and methodological foundation for the ongoing evolution of open-source GraphQL libraries through automation tools and collaborative contribution environments.
+
+### Scope Clarifications
+
+#### Implementation
+
+The scope of the implementation is anchored to the GraphQL JavaScript reference implementation (`graphql-js`) at version 0.6.0. Although the baseline adheres strictly to this version, the project encourages future enhancements through community contributions aligned with extensibility and backward compatibility principles.
+
+Enhancements must avoid disrupting existing functionality unless explicitly motivated by changes in the reference implementation. Stability is paramount, and the implementation is validated through real-world applications in production environments across multiple organizations.
+
+The library reproduces the imperative schema construction model of `graphql-js`, thereby enabling a fully programmable interface to the internal type system. Robustness is ensured by replicating the original unit test suite, adapted idiomatically for Go, to confirm feature parity and behavioral consistency.
+
+#### Compatibility Validation
+
+The compatibility validation tool is designed as an external component, intentionally decoupled from the main implementation. Its modular architecture facilitates support for future integrations with additional GraphQL implementations beyond those evaluated in this study.
+
+The tool verifies runtime equivalence through introspection-based comparisons, focusing on structural compatibility between type systems. The tool also lays the groundwork for CI/CD integration, allowing future maintainers to automate compatibility checks during development workflows.
+
+### Potential Bias Identification
+
+The implementation considers `graphql-js` as its primary design reference. However, adaptations are made to conform with idiomatic Go practices rather than mimicking JavaScript-specific engineering patterns. This translation process emphasizes conceptual fidelity over syntactic replication.
+
+Similarly, the compatibility validation tool is scoped to support `graphql-js` version 0.6.0. Although this version constraint limits its immediate scope, the tool’s modular foundation facilitates future support for newer versions or alternate reference implementations.
+
+### Research Limitations
+
+This research is explicitly limited to evaluating and replicating the behavior of `graphql-js` version 0.6.0. While extensibility is accounted for, validation efforts and conclusions are constrained to this historical version.
+
+### Areas Outside the Scope
+
+#### Resource Limitations
+
+The following initiatives were conceptually considered to further enrich the compatibility validation scope but were excluded from this study due to time and resource constraints. They are proposed as future work:
+
+- **Compatibility Unit Tests** ([GitHub][1]): A framework for validating test name and output alignment between `graphql-js` and `graphql-go`.
+- **Compatibility User Acceptance** ([GitHub][2]): A user-centered analysis comparing community adoption metrics, feedback patterns, and usage characteristics between `graphql-js` and `graphql-go`.
+
+[1]: https://github.com/graphql-go/compatibility-unit-tests  
+[2]: https://github.com/graphql-go/compatibility-user-acceptance
 
 ---
 

--- a/Thesis.md
+++ b/Thesis.md
@@ -383,7 +383,7 @@ This research is explicitly limited to evaluating and replicating the behavior o
 
 The following initiatives were conceptually considered to further enrich the compatibility validation scope but were excluded from this study due to resource constraints. They are proposed as future work:
 
-- **Compatibility Unit Tests** ([GitHub][4]): A framework for validating test name and output alignment between `graphql-js` and `graphql-go`.
+- **Compatibility Unit Tests** ([GitHub][4]): A framework for validating test names alignment between `graphql-js` and `graphql-go`.
 - **Compatibility User Acceptance** ([GitHub][5]): A user-centered analysis comparing community adoption metrics, feedback patterns, and usage characteristics between `graphql-js` and `graphql-go`.
 
 [4]: https://github.com/graphql-go/compatibility-unit-tests

--- a/Thesis.md
+++ b/Thesis.md
@@ -381,13 +381,13 @@ This research is explicitly limited to evaluating and replicating the behavior o
 
 #### Resource Limitations
 
-The following initiatives were conceptually considered to further enrich the compatibility validation scope but were excluded from this study due to time and resource constraints. They are proposed as future work:
+The following initiatives were conceptually considered to further enrich the compatibility validation scope but were excluded from this study due to resource constraints. They are proposed as future work:
 
-- **Compatibility Unit Tests** ([GitHub][1]): A framework for validating test name and output alignment between `graphql-js` and `graphql-go`.
-- **Compatibility User Acceptance** ([GitHub][2]): A user-centered analysis comparing community adoption metrics, feedback patterns, and usage characteristics between `graphql-js` and `graphql-go`.
+- **Compatibility Unit Tests** ([GitHub][4]): A framework for validating test name and output alignment between `graphql-js` and `graphql-go`.
+- **Compatibility User Acceptance** ([GitHub][5]): A user-centered analysis comparing community adoption metrics, feedback patterns, and usage characteristics between `graphql-js` and `graphql-go`.
 
-[1]: https://github.com/graphql-go/compatibility-unit-tests  
-[2]: https://github.com/graphql-go/compatibility-user-acceptance
+[4]: https://github.com/graphql-go/compatibility-unit-tests
+[5]: https://github.com/graphql-go/compatibility-user-acceptance
 
 ---
 

--- a/Thesis.md
+++ b/Thesis.md
@@ -383,7 +383,7 @@ This research is explicitly limited to evaluating and replicating the behavior o
 
 The following initiatives were conceptually considered to further enrich the compatibility validation scope but were excluded from this study due to resource constraints. They are proposed as future work:
 
-- **Compatibility Unit Tests** ([GitHub][4]): A framework for validating test names alignment between `graphql-js` and `graphql-go`.
+- **Compatibility Unit Tests** ([GitHub][4]): A framework for validating unit test names alignment between `graphql-js` and `graphql-go`.
 - **Compatibility User Acceptance** ([GitHub][5]): A user-centered analysis comparing community adoption metrics, feedback patterns, and usage characteristics between `graphql-js` and `graphql-go`.
 
 [4]: https://github.com/graphql-go/compatibility-unit-tests


### PR DESCRIPTION
#### Details
- Closes: #279.
`{thesis,tesis}`: Adds `Development: Scope` sections.

#### Test Plan
:heavy_check_mark: Tested that the `Development: Scope` works as expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new section detailing the research scope, objectives, limitations, and out-of-scope areas in the thesis documentation.
  * Updated the table of contents to reflect the new section and adjusted section numbering accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->